### PR TITLE
Make text larger, page wider

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,7 +27,7 @@ a:hover {
 #wrapper {
     margin: 0 auto;
     padding: 10px;
-    max-width: 600px;
+    max-width: 960px;
 }
 
 @media (min-width: 480px) {
@@ -67,7 +67,7 @@ a:hover {
 
 .ad{
     margin: auto;
-    width: 600px;
+    width: 960px;
 }
 
 #return {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,7 +6,7 @@
 body {
     color: #556270;
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
+    font-size: 14pt;
     font-style: normal;
     font-variant: normal;
     font-weight: normal;
@@ -139,12 +139,11 @@ a:hover {
 }
 
 .status_list .status .st {
-    font-size: 14px;
     font-weight: bold;
 }
 
 .status_list .status .description {
-    font-size: 11px;
+    font-size: 0.8em;
     height: 46px;
     overflow: hidden;
 }


### PR DESCRIPTION
The current descriptions are computed at about 11px, which I find very
difficult to read. These are the minimal changes I could come up with to make
the page more legible. It also changes the content width to 960px from 600px.

![[screenshot](http://cl.ly/image/210J0m433121)](http://f.cl.ly/items/1q0D3h1n3r3K1i1M211m/Image%202014-11-17%20at%2012.11.22%20PM.png)

If this is a welcome change, I'd like to do some more work to make the page a
bit more cohesive and accessible, while also improving the semantics of the
HTML. But I didn't want to start on that if the changes will be rejected.

Thanks for the awesome site!